### PR TITLE
fix FilterBy to support struct pointers

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -150,6 +150,13 @@ func (f *filter) FilterBson(object any) Condition {
 // FilterBy applies filtering based on the fields of the provided object
 func (f *filter) FilterBy(object any) Condition {
 	beanValue := reflect.ValueOf(object)
+	for beanValue.Kind() == reflect.Ptr {
+		if beanValue.IsNil() {
+			f.err = errors.New("needs a struct")
+			return f
+		}
+		beanValue = beanValue.Elem()
+	}
 	if beanValue.Kind() != reflect.Struct {
 		f.err = errors.New("needs a struct")
 		return f

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,25 @@
+package pie
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type person struct {
+	ID   string `bson:"_id,omitempty"`
+	Name string `bson:"name,omitempty"`
+}
+
+func TestFilterByPointer(t *testing.T) {
+	Convey("FilterBy should accept struct pointer", t, func() {
+		f := DefaultCondition()
+		p := &person{ID: "123"}
+		f.FilterBy(p)
+		So(f.Err(), ShouldBeNil)
+		d, err := f.Filters()
+		So(err, ShouldBeNil)
+		So(d, ShouldResemble, bson.D{{Key: "_id", Value: "123"}})
+	})
+}


### PR DESCRIPTION
## Summary
- handle pointer inputs in `filter.FilterBy` so struct pointers can be used to build filters
- add unit test to ensure `FilterBy` accepts pointers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a081894f2c832db3e999219be8e08b